### PR TITLE
Fix the bug init Geo IP before use it in InitConfig.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,15 +72,16 @@ func main() {
 		log.Logger.Errorf("[PANIC] [ConfigPath] %s", err.Error())
 		return
 	}
-	general, err := shuttle.InitConfig(configPath)
-	if err != nil {
-		log.Logger.Errorf("[PANIC] [InitConfig] %s", err.Error())
-		return
-	}
 	var geoIPDB = "GeoLite2-Country.mmdb"
 	err = shuttle.InitGeoIP(geoIPDB)
 	if err != nil {
 		log.Logger.Errorf("[PANIC] [InitGeoIP] %s", err.Error())
+		return
+	}
+	var general *shuttle.General
+	general, err = shuttle.InitConfig(configPath)
+	if err != nil {
+		log.Logger.Errorf("[PANIC] [InitConfig] %s", err.Error())
 		return
 	}
 	// 启动api控制


### PR DESCRIPTION
Fix the bug init Geo IP before use it in InitConfig.

应该先初始化Geo，因为InitConfig会用到Geo的信息，在树莓派上面会有bug,因为初始化Geo会比较慢

``` 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x35aa04]

goroutine 42 [running]:
github.com/oschwald/geoip2-golang.(*Reader).Country(0x0, 0x1c20db0, 0x10, 0x10, 0x1, 0x11, 0x0)
	/Users/admin/go/src/github.com/oschwald/geoip2-golang/reader.go:254 +0x14
github.com/sipt/shuttle.GeoLookUp(0x1c20db0, 0x10, 0x10, 0x0, 0x1)
	/Users/admin/go/src/github.com/sipt/shuttle/geo_ip.go:35 +0xac
github.com/sipt/shuttle.directResolve(0x1973b40, 0x2, 0x2, 0x1878150, 0xffffffff, 0x0)
	/Users/admin/go/src/github.com/sipt/shuttle/dns.go:214 +0x450
github.com/sipt/shuttle.ResolveDomain(0x1878150, 0x1878150, 0x66d7880e)
	/Users/admin/go/src/github.com/sipt/shuttle/dns.go:142 +0x6cc
github.com/sipt/shuttle/protocol.(*ssProtocol).Conn(0x1973ca0, 0x18780e0, 0x70, 0x6b3df0, 0x1, 0x18780e0)
	/Users/admin/go/src/github.com/sipt/shuttle/protocol/ss_protocol.go:45 +0x84
github.com/sipt/shuttle.(*Server).Conn(0x1973c80, 0x18780e0, 0x0, 0x0, 0x0, 0x0)
	/Users/admin/go/src/github.com/sipt/shuttle/server.go:141 +0xd8
github.com/sipt/shuttle/selector.urlTest(0x1973c80, 0x1916000)
	/Users/admin/go/src/github.com/sipt/shuttle/selector/rtt_select.go:95 +0x6c
created by github.com/sipt/shuttle/selector.(*rttSelector).autoTest
	/Users/admin/go/src/github.com/sipt/shuttle/selector/rtt_select.go:84 +0x154
```